### PR TITLE
Fixes #14

### DIFF
--- a/start.sh
+++ b/start.sh
@@ -42,6 +42,20 @@ prep() {
     ${COMPOSE} pull
 }
 
+# Gets the IP of the local machine.
+getIp() {
+    HOSTNAME_VAL="$(hostname -i)"
+
+    if [ -z $HOSTNAME_VAL ]; then
+        IP="127.0.0.1"
+    else
+        IP=$HOSTNAME_VAL
+    fi
+
+    echo $IP
+}
+
+
 # get the IP:port of a container via either the local docker-machine or from
 # sdc-listmachines.
 getIpPort() {
@@ -52,7 +66,7 @@ getIpPort() {
         local ip=$(docker-machine ip default 2>/dev/null || true)
         local port=$(docker inspect ${PREFIX}_$1_1 | json -a NetworkSettings.Ports."$2/tcp".0.HostPort)
     fi
-    echo "${ip:-`hostname -i`}:$port"
+    echo "${ip:-`getIp`}:$port"
 }
 
 # start and initialize the Couchbase cluster, along with Consul


### PR DESCRIPTION
We now detect if the `hostname -i` command returned proper output. If it failed, then we return 127.0.0.1.
