### PR TITLE
Move images to autopilotpattern repo

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,4 +1,4 @@
-triton-touchbase
+Touchbase autopilot pattern
 ==========
 
 *[Autopilot pattern](http://autopilot.io/) implementation of [Touchbase](https://github.com/couchbaselabs/touchbase)*
@@ -19,7 +19,7 @@ Specific components:
 
 ### Running the example
 
-You can run this entire stack using the [`start.sh` script](https://github.com/tgross/triton-touchbase/blob/master/start.sh) found at the top of the repo. 
+You can run this entire stack using the [`start.sh` script](https://github.com/tgross/triton-touchbase/blob/master/start.sh) found at the top of the repo.
 
 Once you're ready:
 

--- a/docker-compose-local.yml
+++ b/docker-compose-local.yml
@@ -23,7 +23,7 @@ consul:
 # Scale this tier and each additional container/instance will automatically
 # self-configure as a member of the cluster
 couchbase:
-    image: misterbisson/triton-couchbase:enterprise-4.0.0-r1
+    image: autopilotpattern/couchbase:enterprise-4.0.0-r1
     restart: always
     links:
         - consul

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -20,7 +20,7 @@ consul:
 # Scale this tier and each additional container/instance will automatically
 # self-configure as a member of the cluster
 couchbase:
-    image: misterbisson/triton-couchbase:enterprise-4.0.0-r1
+    image: autopilotpattern/couchbase:enterprise-4.0.0-r1
     restart: always
     links:
         - consul
@@ -43,7 +43,7 @@ couchbase:
 
 # the main application
 touchbase:
-    image: 0x74696d/triton-touchbase
+    image: autopilotpattern/touchbase
     links:
     - consul
     mem_limit: 1g
@@ -59,7 +59,7 @@ touchbase:
 
 # Nginx as a load-balancing tier and reverse proxy
 nginx:
-    image: 0x74696d/triton-touchbase-demo-nginx
+    image: autopilotpattern/touchbase-demo-nginx
     mem_limit: 512m
     ports:
     - 80

--- a/start.sh
+++ b/start.sh
@@ -292,10 +292,10 @@ scale() {
 release() {
 	docker-compose -p tb -f docker-compose-local.yml build touchbase
 	docker-compose -p tb -f docker-compose-local.yml build nginx
-	docker tag -f tb_touchbase 0x74696d/triton-touchbase
-	docker tag -f tb_nginx 0x74696d/triton-touchbase-demo-nginx
-	docker push 0x74696d/triton-touchbase
-	docker push 0x74696d/triton-touchbase-demo-nginx
+	docker tag -f tb_touchbase autopilotpattern/touchbase
+	docker tag -f tb_nginx autopilotpattern/touchbase-demo-nginx
+	docker push autopilotpattern/touchbase
+	docker push autopilotpattern/touchbase-demo-nginx
 }
 
 while getopts "f:p:h" optchar; do


### PR DESCRIPTION
@misterbisson this updates the repo to have container images moved under the autopilotpattern org.

The new images have been pushed to:
https://hub.docker.com/r/autopilotpattern/touchbase/
https://hub.docker.com/r/autopilotpattern/touchbase-demo-nginx/
https://hub.docker.com/r/autopilotpattern/couchbase/tags/

Same caveat applies about the Nginx image as mentioned in https://github.com/autopilotpattern/cloudflare/pull/3
