### PR TITLE
Fixes local mem_limit for prometheus container

### DIFF
--- a/docker-compose-local.yml
+++ b/docker-compose-local.yml
@@ -82,7 +82,7 @@ nginx:
 # Prometheus server to gather telemetry
 prometheus:
     image: autopilotpattern/prometheus
-    mem_limit: 128g
+    mem_limit: 128m
     restart: always
     ports:
       - "9090:9090"


### PR DESCRIPTION
The limit should be 128M not 128G.
